### PR TITLE
add google tag manager for analytics

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -30,6 +30,7 @@ baseurl: ""
 #disqus: disqus-shortname
 
 #google_analytics: UA-XXXXX-X
+google_tag_manager: G-FXJL4J0WT7
 
 # social icons and sharing options
 social:

--- a/_includes/google_tag_manager.html
+++ b/_includes/google_tag_manager.html
@@ -1,0 +1,9 @@
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id={{ site.google_tag_manager }}"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', '{{ site.google_tag_manager }}');
+</script>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -47,3 +47,6 @@
   <link rel="stylesheet" type="text/css" media="screen" href="{{ "/css/main.css"  | prepend: site.baseurl  }}" />
   <link rel="stylesheet" type="text/css" media="print" href="{{ "/css/print.css"  | prepend: site.baseurl  }}" />
 </head>
+{% if site.google_tag_manager %}
+{% include google_tag_manager.html %}
+{% endif %}


### PR DESCRIPTION
Adds GA tag scripts according to Google instructions. It looks like they just recommend the GA tag script and I don't need an GA UA- key? I'll merge and test to see how things are working.