### PR TITLE
updates github pages to current

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
 # 'github-pages' includes 'jekyll' gem 
-gem 'github-pages'
-gem 'bourbon'
-gem 'jemoji'
+gem 'github-pages', "232"
+gem 'bourbon', "7.3.0"
+gem 'jemoji', "0.13.0"

--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,6 @@
 # Build settings
 plugins:
-#  - jemoji
+  - jemoji
   - jekyll-paginate
 
 # Site settings


### PR DESCRIPTION
I updated the GEMFILE to use the most current version of deps as listed [here](https://pages.github.com/versions/). I'm now able to test locally with `rbenv` so I can test upgrades easier in the future.