### PR TITLE
makes post title responsive on mobile

### DIFF
--- a/css/main.sass
+++ b/css/main.sass
@@ -281,11 +281,17 @@ body
       font-weight: 700
       font-style: normal
       letter-spacing: -0.04em
-      font-size: 50px
-      line-height: 1.1
+      font-size: min(50px, 8vw)  // Scale font size based on viewport width
+      line-height: 1.2
       color: #fff
       margin-bottom: 16px
       text-shadow: 0px 1px 16px rgba(0,0,0,0.5), 0px 0px 1px rgba(0,0,0,0.5)
+      word-wrap: break-word      // Allow long words to break
+      overflow-wrap: break-word  // Modern browsers
+      hyphens: auto             // Enable hyphenation
+      @media(max-width: 700px)
+        font-size: min(40px, 7vw)
+        padding: 0 10px
     .author-image
       display: inline-block
       width: 30px
@@ -330,10 +336,16 @@ body
       font-weight: 700
       font-style: normal
       letter-spacing: -0.04em
-      font-size: 50px
-      line-height: 1.1
+      font-size: min(50px, 8vw)
+      line-height: 1.2
       color: #333332
       margin-bottom: 16px
+      word-wrap: break-word
+      overflow-wrap: break-word
+      hyphens: auto
+      @media(max-width: 700px)
+        font-size: min(40px, 7vw)
+        padding: 0 10px
     .author-image
       display: inline-block
       width: 30px


### PR DESCRIPTION
Long titles don't fit in the header on mobile. The following two posts are most noticable:

 * _posts/2025-05-07-communication-vs-documenation-systems.md
 * _posts/2025-05-09-how-to-communicate-tech-problems-executives-pear.md

Testing locally with resizing the window seems to work. I'm going to merge and test on mobile to be sure.