### PR TITLE
docs: improve project readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,78 +1,54 @@
-mediator
-========
+# The Effortless Manager
 
-A medium inspired Jekyll blog theme. The basic idea came from the Ghost theme
-[Readium 2.0](http://www.svenread.com/readium-ghost-theme/). I use mediator on my own blog [The Base](http://blog.base68.com).
+This repository contains the Jekyll source for the **Effortless Manager** blog.
+It is built with the Mediator theme and published via GitHub Pages.
 
-Screenshots
---------
-![screenshot](/assets/images/screenshot1.jpg)
-![screenshot](/assets/images/screenshot2.jpg)
-![screenshot](/assets/images/screenshot3.jpg)
+## Local development
 
-Features
--------
-* Fully Responsive layout
-* Use header images in articles, if you want to (add tag "image" and url to the image in the front matter section of a post)
-* Minimal design
-* Featured article support
-* FontAwesome implemented for easy use of icons fonts
-* Free & Open Source Font usage
+1. Install Ruby and Bundler.
+2. Install dependencies:
+   ```bash
+   bundle install
+   ```
+3. Serve the site locally:
+   ```bash
+   bundle exec jekyll serve
+   ```
+   The site will be available at <http://localhost:4000>.
 
-Getting Started
----
-- [Fork this repository](https://github.com/dirkfabisch/mediator)
-- Clone it: `git clone https://github.com/YOUR-USER/mediator`
-- Install the requried gems ([GitHub Pages](https://github.com/github/pages-gem), [Bourbon](https://github.com/thoughtbot/bourbon) and [Jekyll](https://github.com/jekyll/jekyll), [Jemoji](https://github.com/jekyll/jemoji)): `bundle install`
-- Run the jekyll server: `bundle exec jekyll serve`
+## Creating a new post
 
-You should have a server up and running locally at <http://localhost:4000>.
+Use the helper script to scaffold a new article:
 
-Configuration
------
-
-The main settings happen in side of the _config.yml file:
-
-### Site
-
-Main settings for the site
-
-* **title**: name of your site
-* **description**: description of your site
-* **logo**: small logo for the site (300x * 300x)
-* **cover**: large background image on the index page
-
-* **name**: name site owner
-* **email**: mail address of the site owner
-* **author**: author name
-* **author_image**: small image of author (300x * 300px)
-* **disqus**: add a disqus forum for your post
-
-### Social
-
-The template allows to add all major social platforms to your site.
-Fill the the form for each platform. If you leave the share_* entries empty, the sharing buttons below a post are not shown.  If you leave the **url** and **desc** empty the icons are not shown on the index page, but the share icons on the article pages remains untouched (Thanks to [Phil](https://github.com/philsturgeon))
-
-* **icon**:	name of social platform (must match a name of [font-awsome](http://fortawesome.github.io/Font-Awesome/) icon set )
-* **url**:	url of your account
-* **desc**: slogan of the platform
-* **share_url**: share url
-* **share_title**: first part of url for the title
-* **share_link**: second part of the share url for the link to the post
-
-The Liquid template engine will magical combine the different parts to a share url.
-
+```bash
+./scripts/create_post.sh my-new-post
 ```
-http://twitter.com/share?text=post_title&amp;url=post_url
-````
 
-See [_config.yml](https://github.com/dirkfabisch/mediator/blob/master/_config.yml) for more examples.
+The script creates:
+- a branch named after your slug,
+- `_posts/DATE-my-new-post.md` with starter front matter,
+- matching directories in `assets/article_images/` and `assets/excalidraw/` for images and diagrams.
 
-Licensing
----------
+Edit the generated file, commit your changes, and open a pull request.
 
-[MIT](https://github.com/dirkfabisch/mediator/blob/master/LICENCE) with no added caveats, so feel free to use this on your site without linking back to me or using a disclaimer or anything silly like that.
+## GitHub Actions
 
-Contact
--------
-I'd love to hear from you at [@dirkfabisch](https://twitter.com/dirkfabisch). Feel free to open issues if you run into trouble or have suggestions. Pull Requests always welcome.
+The workflow `.github/workflows/generate-tags.yml` runs on pushes to `master` and regenerates tag pages.
+It installs Ruby dependencies, runs `scripts/generate_tag_pages.sh`, then commits and pushes any changes back to the repository.
+
+## Repository structure
+
+- `_posts/` – Markdown blog posts.
+- `assets/` – Images, diagrams, and other static assets.
+- `_layouts/` – Page templates.
+- `_includes/` – Reusable HTML snippets.
+- `_sass/` – Sass partials; compiled CSS lives in `css/`.
+- `scripts/` – Utility scripts for post creation and tag generation.
+- `_tag_pages/` – Template files used when generating tag pages.
+- `tags/` – Generated tag pages.
+- `.github/` – GitHub workflow configuration.
+- `initial_posts/` – Sample posts from the theme.
+
+## License
+
+This site is released under the [MIT License](LICENCE).


### PR DESCRIPTION
## Summary
- replace theme readme with project overview and setup instructions
- document script for creating new posts and list top-level directories
- note GitHub Action that regenerates tag pages on push

## Testing
- `bundle install` *(fails: Net::HTTPClientException 403 "Forbidden")*
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*
- `npx markdownlint README.md` *(fails: npm error code E403)*

------
https://chatgpt.com/codex/tasks/task_e_6898b94b5670832987670345cb74983e